### PR TITLE
Add tests for showing compose namespace sidebar

### DIFF
--- a/cypress/integration/advanced-functionalities/compose/namespace/Toggle-sidebar.spec.js
+++ b/cypress/integration/advanced-functionalities/compose/namespace/Toggle-sidebar.spec.js
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+const composeURL = Cypress.env('COMPOSE_URL')
+const email = Cypress.env('USER_EMAIL')
+const password = Cypress.env('USER_PASSWORD')
+
+describe('Testing enable sidebar', () => {
+  before(() => {
+    if (!window.sessionStorage.getItem('auth.refresh-token')) {
+      cy.login({ email, password, url: composeURL })
+    }
+  })
+
+  context('Test for enabling sidebar on a namespace', () => {
+    it('should be enabled by default', () => {
+      cy.visit(composeURL + '/namespaces')
+      cy.get('[data-test-id="button-manage-namespaces"]').click()
+      cy.get('[data-test-id="input-search"]').type('crm')
+      cy.wait(2000)
+      cy.get('tbody').click()
+      cy.get('[data-test-id="checkbox-show-sidebar"]').should('not.be.checked') 
+      cy.get('[data-test-id="button-visit-namespace"]').click()
+      cy.get('aside .b-sidebar-body > div').should('exist')
+    })
+    
+    it('should be able to disable it', () => {
+      cy.visit(composeURL + '/namespaces')
+      cy.get('[data-test-id="button-manage-namespaces"]').click()
+      cy.get('[data-test-id="input-search"]').type('crm')
+      cy.wait(2000)
+      cy.get('tbody').click()
+      cy.get('[data-test-id="checkbox-show-sidebar"]').check({ force: true })
+      cy.get('[data-test-id="checkbox-show-sidebar"]').should('be.checked')
+      cy.get('[data-test-id="button-save"]').click()
+      cy.get('[data-test-id="button-visit-namespace"]').click()
+      cy.wait(2000)
+      cy.get('aside .b-sidebar-body > div').should('not.exist')
+    })
+  })
+})

--- a/cypress/integration/advanced-functionalities/compose/namespace/index.js
+++ b/cypress/integration/advanced-functionalities/compose/namespace/index.js
@@ -1,1 +1,2 @@
 import './Edit.spec'
+import './Toggle-sidebar.spec'


### PR DESCRIPTION
Test if the checkbox in the manage namespace screen shows or hides the sidebar per namespace. Two tests were added to compose: 

First test should pass if there is a checkbox to hide sidebar that is disabled by default. Second test should pass if the sidebar is removed once the checkbox is enabled.